### PR TITLE
Add blog post about FLOSS Weekly interview

### DIFF
--- a/_posts/2020-05-06-floss-weekly.md
+++ b/_posts/2020-05-06-floss-weekly.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  "Presto on FLOSS Weekly"
+author: Dain Sundstrom and Manfred Moser
+excerpt_separator: <!--more-->
+---
+
+Spreading the word about our project is an important task to grow the community
+around Presto. With a large, lively community we can ensure the success of
+Presto. Today we had the opportunity to talk about Presto on the long running
+open source podcast [FLOSS Weekly](https://twit.tv/shows/floss-weekly).
+
+<!--more-->
+
+[Randal Schwartz](http://www.stonehenge.com/merlyn/) was joined by his co-host
+[Simon Phipps](https://webmink.com/about/). We introduced Presto overall and
+talked about use cases of Presto and the problems it can solve. Both hosts, as
+well as the live audience, had some great questions and we did our best to
+answer them.
+
+We moved through the history of Presto, current users and usage, the community
+around the project, and Dain talked about some of the upcoming improvements. In
+the end it seemed like we just scratched the surface and all wanted to keep
+talking about the project.
+
+It was a great conversation and you should check it out!
+
+> ## [Watch a recording of the Presto episode of FLOSS Weekly now!](https://twit.tv/shows/floss-weekly/episodes/577?autostart=false)


### PR DESCRIPTION
We need to confirm that the link to watch the episode is live and correct before we merge and publish. That should happen later today. 

Episode is live now at https://twit.tv/shows/floss-weekly/episodes/577 so we can merge and publish @dain @electrum 