### PR TITLE
Add the presto community broadcast show note pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ defaults:
 collections:
   posts:
     permalink: /blog/:year/:month/:day/:title.html
+  episodes:
+    output: true
 
 exclude:
   - ".gitignore"

--- a/_episodes/1.md
+++ b/_episodes/1.md
@@ -1,0 +1,96 @@
+---
+layout: episode
+title:  "1: What is Presto, WITH RECURSIVE, and Hive connector"
+date: 2020-09-24
+tags: beginner sql hive connector
+youtube_id: "7ARNmiAIXXk"
+wistia_id: "o15xc8h8k7"
+sections: 
+   - title: "Concept of the week"
+     desc: "What is Presto?"
+     time: 1477
+   - title: "PR of the week"
+     desc: "PR 5163 WITH RECURSIVE"
+     time: 2345
+   - title: "Question of the week"
+     desc: "Does the Hive connector depend on the Hive runtime?"
+     time: 2918
+---
+
+Presto nation, We want to hear from you! If you have a question or pull request 
+that you would like us to feature on the show please join the 
+[Presto slack](slack.html) and go to the 
+\#presto-community-broadcast channel and let us know there. Otherwise, you can 
+message Manfred Moser or Brian Olsen directly. Also, feel free to reach out
+to us on our Twitter channels Brian 
+[@bitsondatadev](https://twitter.com/bitsondatadev) and Manfred 
+[@simpligility](https://twitter.com/simpligility).
+
+Today’s concept covers a big overview of what Presto is for those that are new 
+to Presto. For mor information about Presto, check out the following resources:
+[Website](https://prestosql.io/) 
+[Documentation](https://prestosql.io/docs/current/)
+Download the [Free Presto O’Reilly 
+Book](https://www.starburstdata.com/oreilly-presto-guide-download/)  
+Learn [how to contribute](https://prestosql.io/development/) 
+Join our community on the [Presto slack channel](/slack.html)
+
+In this PR we covered [pull request 5163](https://github.com/prestosql/presto
+/pull/5163) which is actually just a documentation update around the existing 
+experimental features of the WITH RECURSIVE feature. The extended development of
+this feature is still being tracked and documented in 
+[issue 1122](https://github.com/prestosql/presto/issues/1122). As with many 
+problems in recursion, the solution space typically exponentially increases and
+so it is something that can easily be misused and cause problems. We run the 
+query and discuss it as well as some of the things that can go wrong. Check out
+ he pull request to see more documentation that was added around it.
+
+In the question of the week, we covered a lot of the confusion around the hive
+connector(https://prestosql.io/docs/current/connector/hive.html). Feel free to 
+try out the katacoda example I created and will be nesting within an 
+[intro to the hive connector blog](blog/2020/10/20/intro-to-hive-connector.html).
+This is running on a non-paid katacoda account so resources are scarce at times
+and it may take a while to load. Nevertheless, the information written around it
+will help you quickly have a Presto environment to play with.
+
+Release Notes discussed:
+<https://prestosql.io/docs/current/release/release-341.html>
+
+Upcoming events
+ - <https://www.meetup.com/BigDataATL/events/273435961/>
+ - <https://edw2020chicago.dataversity.net/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-portland-or-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-minneapolis-mn-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-jacksonville-fl/>
+ - <https://www.evanta.com/cdo/san-francisco/2020-san-francisco-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-detroit-mi/>
+ - <https://www.evanta.com/cdo/atlanta/2020-atlanta-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-providence-ri/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-denver-co/>
+ - <https://www.evanta.com/cdo/boston/2020-boston-cdo-virtual-executive-summit>
+
+Latest training from David, Dain, and Martin:
+<https://prestosql.io/blog/2020/07/15/training-advanced-sql.html>
+<https://prestosql.io/blog/2020/07/30/training-query-tuning.html>
+<https://prestosql.io/blog/2020/08/13/training-security.html>
+<https://prestosql.io/blog/2020/08/27/training-performance.html>
+
+Presto Summit Series - Real world usage
+<https://prestosql.io/blog/2020/05/15/state-of-presto.html>
+<https://prestosql.io/blog/2020/06/16/presto-summit-zuora.html>
+<https://prestosql.io/blog/2020/07/06/presto-summit-arm-td.html>
+<https://prestosql.io/blog/2020/07/22/presto-summit-pinterest.html>
+
+Recent Podcasts:
+<https://www.contributor.fyi/presto>
+<https://www.dataengineeringpodcast.com/presto-distributed-sql-episode-149/>
+
+
+If you want to learn more about Presto yourself, you should check out the 
+O’Reilly Presto Definitive guide. You can download 
+[the free PDF](https://www.starburstdata.com/oreilly-presto-guide-download/) or 
+buy the book online.
+
+Music for the show is from the [Megaman 6 Game Play album by Krzysztof 
+Słowikowski](https://krzysztofslowikowski.bandcamp.com/album/mega-man-6-gp).
+

--- a/_episodes/2.md
+++ b/_episodes/2.md
@@ -1,0 +1,108 @@
+---
+layout: episode
+title:  "2: Kubernetes, arrays on Elasticsearch, and security breaks the UI"
+date: 2020-10-07
+tags: kubernetes use-case interview elasticsearch ui security
+youtube_id: "MCbdpGIgniU"
+wistia_id: "3d53rdmljh"
+sections: 
+   - title: "Presto Event"
+     desc: "Presto for any company size"
+     time: 889
+   - title: "Concept of the week"
+     desc: "Presto on Kubernetes"
+     time: 1699
+   - title: "PR of the week"
+     desc: "PR 2441 Add array support using the _meta mapping in Elasticsearch"
+     time: 2484
+   - title: "Question of the week"
+     desc: "Why does my Presto UI say web interface disabled?"
+     time: 3306
+---
+
+Presto nation, We want to hear from you! If you have a question or pull request 
+that you would like us to feature on the show please join the 
+[Presto slack](slack.html) and go to the 
+\#presto-community-broadcast channel and let us know there. Otherwise, you can 
+message Manfred Moser or Brian Olsen directly. Also, feel free to reach out
+to us on our Twitter channels Brian 
+[@bitsondatadev](https://twitter.com/bitsondatadev) and Manfred 
+[@simpligility](https://twitter.com/simpligility).
+
+This week we had a bit of a technical issue between zoom and OBS so there was 
+some editing done to remove a portion of the broadcast which mainly cuts out us 
+covering the releases. We circle back and give a small summary but unfortunately
+ lost the majority of that part of the conversation.
+
+In this week’s concept, we cover a general overview of kubernetes and how 
+kubernetes is used when deploying and scaling up Presto. We also dive into how 
+this is being used at our guest Cory Darby’s company, BlueCat.
+
+In this week's pull request covers a pull request 
+<https://github.com/prestosql/presto/pull/2462> which closes ticket 
+<https://github.com/prestosql/presto/issues/2441>. This was actually a PR Brian
+submitted some months ago. He dives into a bit about 
+[Elasticsearch mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html) 
+and how Elasticsearch models their data. He then covers how this motivated the 
+pull request addressing the need for explicit mappings of which elasticsearch 
+fields are array types vs scalar.
+
+In this week's question, we answer, “Why does the web ui say “disabled”?” This 
+typically comes from a security setup issue and there’s another similar issue
+ when you are using a proxy that we cover as a bonus.
+
+Release Notes discussed:
+<https://prestosql.io/docs/current/release/release-342.html>
+<https://prestosql.io/docs/current/release/release-343.html>
+
+Manfred’s Training - SQL at any scale
+<https://www.simpligility.com/2020/10/join-me-for-presto-first-steps/>
+<https://learning.oreilly.com/live-training/courses/presto-first-steps
+/0636920462859/>
+
+Blogs
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-creating-a-single-point-of-access-to-multiple-postgres-servers-using-starburst-presto>
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-unlock-data-in-postgres-servers-to-query-it-with-other-data-sources-like-hive-kafka-other-dbmss-and-more>
+
+<https://medium.com/@joshua_robinson/presto-and-fast-object-putting-backups-to-use-for-devops-and-machine-learning-s3-46876eef4ffa>
+
+
+Upcoming events
+ - <https://www.meetup.com/BigDataATL/events/273435961/>
+ - <https://edw2020chicago.dataversity.net/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-portland-or-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-minneapolis-mn-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-jacksonville-fl/>
+ - <https://www.evanta.com/cdo/san-francisco/2020-san-francisco-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-detroit-mi/>
+ - <https://www.evanta.com/cdo/atlanta/2020-atlanta-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-providence-ri/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-denver-co/>
+ - <https://www.evanta.com/cdo/boston/2020-boston-cdo-virtual-executive-summit>
+
+Latest training from David, Dain, and Martin:
+<https://prestosql.io/blog/2020/07/15/training-advanced-sql.html>
+<https://prestosql.io/blog/2020/07/30/training-query-tuning.html>
+<https://prestosql.io/blog/2020/08/13/training-security.html>
+<https://prestosql.io/blog/2020/08/27/training-performance.html>
+
+Presto Summit Series - Real world usage
+<https://prestosql.io/blog/2020/05/15/state-of-presto.html>
+<https://prestosql.io/blog/2020/06/16/presto-summit-zuora.html>
+<https://prestosql.io/blog/2020/07/06/presto-summit-arm-td.html>
+<https://prestosql.io/blog/2020/07/22/presto-summit-pinterest.html>
+
+Recent Podcasts:
+<https://www.contributor.fyi/presto>
+<https://www.dataengineeringpodcast.com/presto-distributed-sql-episode-149/>
+
+If you want to learn more about Presto yourself, you should check out the 
+O’Reilly Presto Definitive guide. You can download 
+[the free PDF](https://www.starburstdata.com/oreilly-presto-guide-download/) or 
+buy the book online.
+
+Music for the show is from the [Megaman 6 Game Play album by Krzysztof 
+Słowikowski](https://krzysztofslowikowski.bandcamp.com/album/mega-man-6-gp). 
+

--- a/_episodes/3.md
+++ b/_episodes/3.md
@@ -1,0 +1,109 @@
+---
+layout: episode
+title:  "3: Running two Presto distributions and Kafka headers as Presto columns"
+date: 2020-10-22
+tags: starburst use-case interview kafka
+youtube_id: "X77FAfIf1Qo"
+wistia_id: "hk6vj5x18w"
+sections: 
+   - title: "Interview"
+     desc: "Using multiple Presto distributions"
+     time: 1810
+   - title: "PR of the week"
+     desc: "PR 4462 Add Kafka headers as columns"
+     time: 3095
+---
+
+Presto nation, We want to hear from you! If you have a question or pull request 
+that you would like us to feature on the show please join the 
+[Presto slack](slack.html) and go to the 
+\#presto-community-broadcast channel and let us know there. Otherwise, you can 
+message Manfred Moser or Brian Olsen directly. Also, feel free to reach out
+to us on our Twitter channels Brian 
+[@bitsondatadev](https://twitter.com/bitsondatadev) and Manfred 
+[@simpligility](https://twitter.com/simpligility).
+
+In this week’s concept, Manfred discusses what an SPI (service provider 
+interface) is and covers the connector architecture of Presto, Starburst, and 
+Custom.
+
+In this week's pull request <https://github.com/prestosql/presto/pull/4462>, 
+came from user [Sven Pfennig](https://github.com/0xE282B0). Sven works for 
+[Syncier GmbH](syncier.com) and as part of his role there he gets to contribute
+to open source projects such as Presto. Thanks Sven! We jump into a quick setup
+of a kafka broker using the 
+[kafka quickstart tutorial](https://kafka.apache.org/quickstart) and I use the 
+[kafkacat tool](https://github.com/edenhill/kafkacat) to show off the addition 
+of headers in Kafka that Sven has provided us and discuss why this is 
+beneficial.
+
+Here’s the crazy select statement I used to decode the binary values to utf text
+of the foo column
+```
+SELECT 
+   _message, 
+   reduce(element_at(_headers,'foo'), '', (s, c) -> s || from_utf8(c), s -> s) AS foo 
+FROM kafka.default.pcb 
+WHERE contains(map_keys(_headers), 'foo');
+```
+
+An alternative tutorial that uses the TPC dataset can be located on the presto site. 
+<https://prestosql.io/docs/current/connector/kafka-tutorial.html>
+
+This weeks question was accidentally cut off as I had mapped my Shift + R key to
+toggle streaming/recording and this cut the broadcast when I typed the R in
+FROM.
+
+Release Notes discussed:
+<https://prestosql.io/docs/current/release/release-344.html>
+
+Manfred’s Training - SQL at any scale
+<https://www.simpligility.com/2020/10/join-me-for-presto-first-steps/>
+<https://learning.oreilly.com/live-training/courses/presto-first-steps/0636920462859/>
+
+Blogs
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-creating-a-single-point-of-access-to-multiple-postgres-servers-using-starburst-presto>
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-unlock-data-in-postgres-servers-to-query-it-with-other-data-sources-like-hive-kafka-other-dbmss-and-more>
+
+<https://blog.bigdataboutique.com/2020/09/presto-meets-elasticsearch-our-elasticsearch-connector-for-presto-video-mbywtm >
+
+
+Upcoming events
+ - <https://www.meetup.com/BigDataATL/events/273435961/>
+ - <https://edw2020chicago.dataversity.net/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-portland-or-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-minneapolis-mn-2/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-jacksonville-fl/>
+ - <https://www.evanta.com/cdo/san-francisco/2020-san-francisco-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-detroit-mi/>
+ - <https://www.evanta.com/cdo/atlanta/2020-atlanta-cdo-virtual-executive-summit>
+ - <https://techtalksummits.com/event/virtual-commercial-it-providence-ri/>
+ - <https://techtalksummits.com/event/virtual-commercial-it-denver-co/>
+ - <https://www.evanta.com/cdo/boston/2020-boston-cdo-virtual-executive-summit>
+
+Latest training from David, Dain, and Martin:
+<https://prestosql.io/blog/2020/07/15/training-advanced-sql.html>
+<https://prestosql.io/blog/2020/07/30/training-query-tuning.html>
+<https://prestosql.io/blog/2020/08/13/training-security.html>
+<https://prestosql.io/blog/2020/08/27/training-performance.html>
+
+Presto Summit Series - Real world usage
+<https://prestosql.io/blog/2020/05/15/state-of-presto.html>
+<https://prestosql.io/blog/2020/06/16/presto-summit-zuora.html>
+<https://prestosql.io/blog/2020/07/06/presto-summit-arm-td.html>
+<https://prestosql.io/blog/2020/07/22/presto-summit-pinterest.html>
+
+Recent Podcasts:
+<https://www.contributor.fyi/presto>
+<https://www.dataengineeringpodcast.com/presto-distributed-sql-episode-149/>
+
+If you want to learn more about Presto yourself, you should check out the 
+O’Reilly Presto Definitive guide. You can download 
+[the free PDF](https://www.starburstdata.com/oreilly-presto-guide-download/) or 
+buy the book online.
+
+Music for the show is from the [Megaman 6 Game Play album by Krzysztof 
+Słowikowski](https://krzysztofslowikowski.bandcamp.com/album/mega-man-6-gp).
+

--- a/_episodes/4.md
+++ b/_episodes/4.md
@@ -1,0 +1,169 @@
+---
+layout: episode
+title:  "4: Presto on ACID, row-level INSERT/DELETE, and why JDK11?"
+date: 2020-11-04
+tags: starburst company kafka
+youtube_id: "5-7yjewo5iI"
+wistia_id: "wqhhhs78rb"
+sections: 
+   - title: "Concept of the week"
+     desc: "Presto on ACID"
+     time: 1175
+   - title: "PR of the week"
+     desc: "PR 5402 Hive ACID row-level INSERT and DELETE"
+     time: 1644
+   - title: "PR Demo"
+     desc: "Hive ACID row-level INSERT and DELETE demo"
+     time: 2546
+   - title: "Question of the week"
+     desc: "Why is JDK 11 required to run Presto and how can I revert to JDK8?"
+     time: 3259
+---
+
+Presto nation, We want to hear from you! If you have a question or pull request 
+that you would like us to feature on the show please join the 
+[Presto slack](slack.html) and go to the 
+\#presto-community-broadcast channel and let us know there. Otherwise, you can 
+message Manfred Moser or Brian Olsen directly. Also, feel free to reach out
+to us on our Twitter channels Brian 
+[@bitsondatadev](https://twitter.com/bitsondatadev) and Manfred 
+[@simpligility](https://twitter.com/simpligility).
+
+In this week’s concept, Manfred discusses the ACID in general, CAP theorem, 
+HDFS and Hive aspects originally, now ORC ACID and similar support.
+
+ACID <https://en.wikipedia.org/wiki/ACID>
+ - Atomicity - transaction completely succeeds or completely fails, no partial 
+results, so no inconsistent relationships left tangling and such, db remains in
+a consistent state
+ - Consistency - database content always adheres to defined rules (key
+ constraints)
+ - Isolation, transactions are isolated from each other and can run in parallel
+  with same result as sequentially
+ - Durability - no data is lost after transaction completion
+
+Used to be a crucial criteria for a “serious” relational database system.
+
+Then came big data and the CAP theorem. <https://en.wikipedia.org/wiki/CAP_theorem>
+ - Consistency
+ - Availability
+ - Partition tolerance
+
+In this week's pull request <https://github.com/prestosql/presto/pull/5402>, 
+came from user [David Stryker](https://github.com/djsstarburst). David covers
+some of the interesting aspects to workin on this pull request. This commit adds
+support for row-level insert and delete for Hive ACID tables, and product tests
+that verify that row-level insert and delete where allowed.
+
+Here’s is the SQL that we ran in the INSERT/DELETE demo
+```
+/*
+  Ran against Presto
+*/
+SHOW SCHEMAS IN minio;
+SHOW TABLES IN minio.acid;
+
+CREATE SCHEMA minio.acid
+WITH (location = 's3a://acid/');
+
+
+CREATE TABLE minio.acid.test (a int, b int) 
+WITH (
+   format='ORC', 
+   transactional=true
+);
+
+INSERT INTO minio.acid.test VALUES (10, 10), (20, 20);
+
+SELECT * FROM  minio.acid.test;
+
+DELETE FROM minio.acid.test WHERE a = 10;
+
+/*
+  Ran against Hive
+*/
+
+SHOW DATABASES;
+
+SELECT * FROM acid.test;
+```
+
+David also mentioned [this blog](http://shzhangji.com/blog/2019/06/10/understanding-hive-acid-transactional-table/)
+to better understand the hive acid model.
+
+In this week's question, we answer, “Why is Java 11 needed in the newer version
+of Presto and how do I get the older version of Presto as I need the 328 latest 
+on Java 8 as Java 11 isn’t available to use?
+
+Using Java 11 because it is the next LTS verison of java since 8. Java 11 
+provides significant performance and stability improvements, so we believe 
+everyone should be running that version to get the best experience out of 
+Presto. Moving to Java 11 allows us to take advantage of many improvements to 
+the JDK and the Java language that were introduced since Java 8.
+
+For older versions, you can download it from maven or an older document version.
+<https://repo.maven.apache.org/maven2/io/prestosql/presto-server/>
+<https://prestosql.github.io/docs.prestosql.io/328/>
+
+One thing to point out is you're only required to use JDK11 for the server. The
+client can be on JDK8. One reason you would need to run Presto on JDK8 is if the
+server had to be run with another service running JDK8 which we do not recommend
+as this will degrade the performance of your cluster and could cause other
+issues if Presto is fighting for resources. 
+
+Another possibility is that there is
+a company policy requiring specific JDKs be installed on all servers. You can
+have side-by-side installs of multiple versions of the JDK and use the
+appropriate one. You just need to launch Presto with the correct java command. 
+If your company is against using a newer JDK, you can point out the arguments
+above to update the policy to at least include JDK11.
+
+Release Notes discussed:
+<https://prestosql.io/docs/current/release/release-344.html>
+
+Manfred’s Training - SQL at any scale
+<https://www.simpligility.com/2020/10/join-me-for-presto-first-steps/>
+<https://learning.oreilly.com/live-training/courses/presto-first-steps/0636920462859/>
+
+Blogs
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-creating-a-single-point-of-access-to-multiple-postgres-servers-using-starburst-presto>
+
+<https://postgresconf.org/conferences/postgres-webinar-series/program/proposals/live-demo-unlock-data-in-postgres-servers-to-query-it-with-other-data-sources-like-hive-kafka-other-dbmss-and-more>
+
+<https://blog.bigdataboutique.com/2020/09/presto-meets-elasticsearch-our-elasticsearch-connector-for-presto-video-mbywtm >
+
+Upcoming events
+ - Nov 12 Webinar: <https://www.starburstdata.com/webinar-lower-cdw-costs-starburst>
+ - Nov 17 <https://databricks.com/session_eu20/presto-fast-sql-on-anything-including-delta-lake-snowflake-elasticsearch-and-more>
+ - Nov 19 <https://techtalksummits.com/event/virtual-commercial-it-detroit-mi/>
+ - Dec 2 <https://www.evanta.com/cdo/atlanta/2020-atlanta-cdo-virtual-executive-summit>
+ - Dec 9 <https://techtalksummits.com/event/virtual-commercial-it-providence-ri/>
+ - Dec 10 <https://techtalksummits.com/event/virtual-commercial-it-denver-co/>
+ - Dec 10 <https://www.evanta.com/cdo/san-francisco/2020-san-francisco-cdo-virtual-executive-summit>
+ - Dec 16 <https://www.evanta.com/cdo/boston/2020-boston-cdo-virtual-executive-summit>
+
+Latest training from David, Dain, and Martin(Now with timestamps!):
+<https://prestosql.io/blog/2020/07/15/training-advanced-sql.html>
+<https://prestosql.io/blog/2020/07/30/training-query-tuning.html>
+<https://prestosql.io/blog/2020/08/13/training-security.html>
+<https://prestosql.io/blog/2020/08/27/training-performance.html>
+
+Presto Summit Series - Real world usage
+<https://prestosql.io/blog/2020/05/15/state-of-presto.html>
+<https://prestosql.io/blog/2020/06/16/presto-summit-zuora.html>
+<https://prestosql.io/blog/2020/07/06/presto-summit-arm-td.html>
+<https://prestosql.io/blog/2020/07/22/presto-summit-pinterest.html>
+
+Recent Podcasts:
+<https://www.contributor.fyi/presto>
+<https://www.dataengineeringpodcast.com/presto-distributed-sql-episode-149/>
+
+If you want to learn more about Presto yourself, you should check out the 
+O’Reilly Presto Definitive guide. You can download 
+[the free PDF](https://www.starburstdata.com/oreilly-presto-guide-download/) or 
+buy the book online.
+
+Music for the show is from the [Megaman 6 Game Play album by Krzysztof 
+Słowikowski](https://krzysztofslowikowski.bandcamp.com/album/mega-man-6-gp).
+

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+    <link rel="stylesheet" href="{{ '/assets/episode/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+  <link rel="alternate" href="{{ '/broadcast/feed.xml' | relative_url }}" type="application/atom+xml" title="Presto Community Broadcast Episode">
+  {%- include google-analytics.html -%}
+</head>
+
+<body>
+  {%- include header.html -%}
+  <header class="hero clearfix">
+      <div class="width">
+          <h1>Presto Community Broadcast</h1>
+      </div>
+  </header>
+
+  <div class="content width clearfix">
+      <h1>{{ page.title }}</h1>
+
+      <h2>Audio</h2>
+      <script
+              src="https://fast.wistia.com/embed/medias/{{ page.wistia_id }}.jsonp" async>
+      </script>
+      <script
+              src="https://fast.wistia.com/assets/external/E-v1.js" async>
+      </script>
+      <div class="wistia_embed wistia_async_{{ page.wistia_id }} seo=false"
+           style="width:100%;height:218px;position:relative">&nbsp;
+      </div>
+
+      <h2>Video</h2>
+      <div class="youtube-video-container">
+          <iframe width="720" height="405" src="https://www.youtube.com/embed/{{ page.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+      </div>
+
+      <h3>Video sections</h3>
+      <ul>
+          {% for section in page.sections %}
+          <li>
+              {{section.title}}:
+              <a href="https://www.youtube.com/watch?v={{ page.youtube_id }}&t={{ section.time }}s" target="_blank">
+               {{ section.desc }}
+              </a>
+          </li>
+          {% endfor %}
+      </ul>
+
+      <h2>Show notes</h2>
+      {{ content }}
+  </div>
+
+  {%- include footer.html -%}
+
+</body>
+</html>

--- a/assets/episode/main.css
+++ b/assets/episode/main.css
@@ -1,0 +1,35 @@
+---
+---
+
+.svg-icon {
+    width: 25px;
+    height: 25px;
+    display: inline-block;
+    fill: #{$grey-color};
+    padding-right: 5px;
+    vertical-align: text-top;
+}
+
+.rss-subscribe .svg-icon {
+  margin-left: 10px;
+}
+
+.youtube-video-container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+}
+
+.youtube-video-container::after {
+  display: block;
+  content: "";
+  padding-top: 56.25%;
+}
+
+.youtube-video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/broadcast/episodes.md
+++ b/broadcast/episodes.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: Presto Community Broadcast Episodes
+---
+
+<link rel="stylesheet" href="{{ '/assets/episode/main.css' | relative_url }}">
+<div class="home">
+  <div>
+  </div>
+  {% for episode in site.episodes reversed %}
+  <div class="post-entry">
+
+    <h1><a class="post-link" href="{{ episode.url | relative_url }}">{{ episode.title | escape }}</a></h1>
+    <span class="post-meta">{{ episode.date | date: "%b %-d, %Y" }}
+    </span>
+    <ul>
+          {% for section in episode.sections %}
+          <li>
+              {{section.title}}:
+              <a href="https://www.youtube.com/watch?v={{ episode.youtube_id}}&t={{ section.time }}s" target="_blank">
+               {{ section.desc }}
+              </a>
+          </li>
+          {% endfor %}
+      </ul>
+    <a href="{{ site.baseurl }}{{ episode.url }}">Listen, watch, or read the show notes...</a>
+
+  </div>
+  {% endfor %}
+
+  <p class="rss-subscribe">
+    <a href="{{ '/broadcast/feed.xml' | relative_url }}">subscribe via RSS</a>
+    <svg class="svg-icon"><use xlink:href="{{ '/assets/blog/social-icons.svg#rss' | relative_url }}"></use></svg>
+  </p>
+</div>

--- a/broadcast/feed.xml
+++ b/broadcast/feed.xml
@@ -1,0 +1,38 @@
+---
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml" />
+  <link href="{{ '/broadcast/' | absolute_url }}" rel="alternate" type="text/html" />
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url | xml_escape }}</id>
+
+  <title>Presto Blog</title>
+
+  <subtitle>{{ site.description | xml_escape }}</subtitle>
+
+  {% for episode in site.episodes reversed %}
+    <entry>
+      <title>{{ episode.title | strip_html | normalize_whitespace | xml_escape }}</title>
+      <link href="{{ episode.url | absolute_url }}" rel="alternate" type="text/html" title="{{ episode.title | xml_escape }}" />
+      <published>{{ episode.date | date_to_xmlschema }}</published>
+      <updated>{{ episode.last_modified_at | default: episode.date | date_to_xmlschema }}</updated>
+      <id>{{ episode.id | absolute_url | xml_escape }}</id>
+      <content type="html" xml:base="{{ episode.url | absolute_url | xml_escape }}">{{ episode.content | strip | xml_escape }}</content>
+
+      {% if episode.author %}
+        <author>
+          <name>{{ episode.author | xml_escape }}</name>
+        </author>
+      {% endif %}
+
+      <summary>{{ episode.excerpt | strip_html | normalize_whitespace | xml_escape }}</summary>
+
+      {% assign episode_image = episode.image.path | default: episode.image | absolute_url %}
+      {% if episode_image %}
+        <media:thumbnail xmlns:media="http://search.yahoo.com/mrss/" url="{{ episode_image | xml_escape }}" />
+      {% endif %}
+    </entry>
+  {% endfor %}
+</feed>

--- a/broadcast/index.md
+++ b/broadcast/index.md
@@ -1,0 +1,46 @@
+---
+layout: page
+title: Presto Community Broadcast
+---
+
+<div markdown="1" class="leftcol widecol">
+
+With great data comes even greater access latency. Welcome to the Presto 
+Community Broadcast where we transform your latency woes to fast insights.
+Presto Community Broadcast is a show where we cover events and happenings within
+the open-source Presto community and show off some cool stuff about Presto.
+
+Presto nation, We want to hear from you! If you have a question or pull request 
+that you would like us to feature on the show please join the 
+[Presto slack](https://prestosql.io/slack) and go to the 
+`#presto-community-broadcast` channel and let us know there. Otherwise, you can
+message Manfred Moser or Brian Olsen directly on Slack or Twitter.
+
+Remember, for fast data at resto, Presto is the besto! See us live every two
+weeks!
+
+
+<a class="button" href="/broadcast/episodes.html">See past episodes!</a>
+
+## Co-hosts
+
+ - Brian Olsen [@bitsondatadev](https://twitter.com/bitsondatadev)
+ - Manfred Moser [@simpligility](https://twitter.com/simpligility)
+
+## Where to watch or listen
+
+ - Watch live on <a href="https://www.twitch.tv/prestosql" target="_blank">Presto Twitch</a>.
+ - Watch later on <a href="https://www.youtube.com/playlist?list=PLFnr63che7war_NzC7CJQjFuUKLYC7nYh" target="_blank">Youtube PCB Playlist</a>.
+ - Listen on <a href="https://podcasts.apple.com/us/podcast/presto-community-broadcast/id1533484786" target="_blank">Apple Podcast</a>.
+ - Listen on <a href="https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xMzc0NTMyLnJzcw==" target="_blank">Google Podcast</a>.
+ - Listen on <a href="https://open.spotify.com/show/53ZrVCCmZSsEmvlNfzpWSL" target="_blank">Spotify</a>.
+
+# Upcoming shows
+ <ul>
+    <li>
+        Datetime: Thursday, November 19, 2020, at 1:00 pm -0500 <br/>
+        Topic(s): Hive Partitions
+    </li>
+ </ul>
+
+</div>

--- a/community.md
+++ b/community.md
@@ -13,6 +13,7 @@ title: Community
   [@prestosql](https://twitter.com/prestosql)
   [#prestosql](https://twitter.com/search?q=%23prestosql)
   [#prestodb](https://twitter.com/search?q=%23prestodb)
+* **Live Show and Podcast:** [Presto Community Broadcast](/broadcast/)
 * **YouTube:** [Presto Channel](https://www.youtube.com/channel/UCpqxUwvIA6vaXW45KO1GMhA)
 * **Mailing List:** [presto-users](https://groups.google.com/group/presto-users) (legacy, Slack is preferred)
 


### PR DESCRIPTION
These episode pages work similar to the blog pages but are on a distinct rss feed and page. They are linked from Community > Presto Community Broadcast > Show Notes. 

TODO  before we commit.
 ~1) invert list order to most recent on top.~